### PR TITLE
Fix csapi query filter mismatches and missing headers in cscoco

### DIFF
--- a/src/csapi.py
+++ b/src/csapi.py
@@ -51,24 +51,24 @@ SAVED_QUERIES_FILES = {
     "readonly": {"where": "f.RO = 1"},
     "with_unused": {
         "join": "JOIN TOKENS t ON t.FID = f.FID JOIN IDS i ON i.EID = t.EID",
-        "where": "i.UNUSED = 1 AND i.READONLY = 0",
+        "where": "i.UNUSED = 1 AND i.READONLY = 0 AND i.MACROARG = 0",
         "distinct": True
     },
     "no_statements": {
         "join": "JOIN FILEMETRICS fm ON fm.FID = f.FID",
-        "where": "fm.PRECPP = 0 AND f.NAME LIKE '%.c' AND (fm.NSTMT = 0 OR fm.NSTMT IS NULL)"
+        "where": "f.RO = 0 AND fm.PRECPP = 0 AND f.NAME LIKE '%.c' AND (fm.NSTMT = 0 OR fm.NSTMT IS NULL)"
     },
     "unprocessed": {
         "join": "JOIN FILEMETRICS fm ON fm.FID = f.FID",
-        "where": "fm.PRECPP = 0 AND fm.NULINE > 0"
+        "where": "f.RO = 0 AND fm.PRECPP = 0 AND fm.NULINE > 0"
     },
     "with_strings": {
         "join": "JOIN FILEMETRICS fm ON fm.FID = f.FID",
-        "where": "fm.PRECPP = 0 AND fm.NSTRING > 0"
+        "where": "f.RO = 0 AND fm.PRECPP = 0 AND fm.NSTRING > 0"
     },
     "h_with_includes": {
         "join": "JOIN FILEMETRICS fm ON fm.FID = f.FID",
-        "where": "f.NAME LIKE '%.h' AND fm.PRECPP = 1 AND fm.NINCFILE > 0"
+        "where": "f.RO = 0 AND f.NAME LIKE '%.h' AND fm.PRECPP = 1 AND fm.NINCFILE > 0"
     }
 }
 
@@ -78,10 +78,10 @@ SAVED_QUERIES_IDS = {
     "unused_project": {"where": "i.UNUSED = 1 AND i.LSCOPE = 1 AND i.READONLY = 0 AND i.MACROARG = 0"},
     "unused_file": {"where": "i.UNUSED = 1 AND i.CSCOPE = 1 AND i.READONLY = 0 AND i.MACROARG = 0"},
     "unused_macros": {"where": "i.UNUSED = 1 AND i.MACRO = 1 AND i.READONLY = 0 AND i.MACROARG = 0"},
-    "file_spanning": {"where": "i.READONLY = 0 AND i.EID IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
+    "file_spanning": {"where": "i.READONLY = 0 AND i.MACROARG = 0 AND i.EID IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
     "static_vars": {"where": "i.READONLY = 0 AND i.FUN = 0 AND i.ORDINARY = 1 AND i.LSCOPE = 1 AND i.NAME != 'main' AND i.EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
     "static_funs": {"where": "i.FUN = 1 AND i.READONLY = 0 AND i.ORDINARY = 1 AND i.LSCOPE = 1 AND i.NAME != 'main' AND i.EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
-    "unused": {"where": "i.UNUSED = 1 AND i.READONLY = 0"},
+    "unused": {"where": "i.UNUSED = 1 AND i.READONLY = 0 AND i.MACROARG = 0"},
     "should_be_static": {"where": "i.READONLY = 0 AND i.ORDINARY = 1 AND i.LSCOPE = 1 AND i.NAME != 'main' AND i.EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
     "functions": {"where": "i.FUN = 1"}
 }

--- a/src/csapi.py
+++ b/src/csapi.py
@@ -79,8 +79,11 @@ SAVED_QUERIES_IDS = {
     "unused_file": {"where": "i.UNUSED = 1 AND i.CSCOPE = 1 AND i.READONLY = 0 AND i.MACROARG = 0"},
     "unused_macros": {"where": "i.UNUSED = 1 AND i.MACRO = 1 AND i.READONLY = 0 AND i.MACROARG = 0"},
     "file_spanning": {"where": "i.READONLY = 0 AND i.EID IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
-    "static_vars": {"where": "i.READONLY = 0 AND i.ORDINARY = 1 AND i.LSCOPE = 1 AND i.NAME != 'main' AND i.EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
+    "static_vars": {"where": "i.READONLY = 0 AND i.FUN = 0 AND i.ORDINARY = 1 AND i.LSCOPE = 1 AND i.NAME != 'main' AND i.EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
     "static_funs": {"where": "i.FUN = 1 AND i.READONLY = 0 AND i.ORDINARY = 1 AND i.LSCOPE = 1 AND i.NAME != 'main' AND i.EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
+    "unused": {"where": "i.UNUSED = 1 AND i.READONLY = 0"},
+    "should_be_static": {"where": "i.READONLY = 0 AND i.ORDINARY = 1 AND i.LSCOPE = 1 AND i.NAME != 'main' AND i.EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
+    "functions": {"where": "i.FUN = 1"}
 }
 
 SAVED_QUERIES_FUNCTIONS = {

--- a/src/cscoco.py
+++ b/src/cscoco.py
@@ -125,10 +125,19 @@ def generate_cs(compile_commands_file, project_name):
 
     predefs = os.path.join(instdir, 'csmake-pre-defs.h')
     postdefs = os.path.join(instdir, 'csmake-post-defs.h')
+    hostdefs = os.path.join(instdir, 'host-defs.h')
+    hostincs = os.path.join(instdir, 'host-incs.h')
 
     if not os.path.exists(predefs):
         print(
             'Error: workaround headers not found.\n'
+            'Please refer to the CScout installation instructions.',
+            file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.exists(hostdefs) or not os.path.exists(hostincs):
+        print(
+            'Error: host-defs.h or host-incs.h not found.\n'
             'Please refer to the CScout installation instructions.',
             file=sys.stderr)
         sys.exit(1)
@@ -160,9 +169,15 @@ def generate_cs(compile_commands_file, project_name):
         print('#pragma clear_include')
         print(f'#pragma pushd "{directory}"')
 
-        # Pre-defs supply CScout's mock standard headers and the
-        # built-in compiler macro definitions (e.g. __GNUC__).
+        # Pre-defs supply CScout's mock standard headers.
+        # host-defs supplies the actual compiler's built-in macro
+        # definitions (e.g. __GNUC__) since csmake-pre-defs.h
+        # deliberately omits these (it targets the csmake workflow,
+        # where a real compiler provides them separately).
+        # host-incs supplies the actual system include search paths.
         print(f'#include "{predefs}"')
+        print(f'#include "{hostdefs}"')
+        print(f'#include "{hostincs}"')
 
         for d in defines:
             if '=' in d:


### PR DESCRIPTION
## Summary

**csapi.py**

Some of the saved query filters were missing conditions that their matching count queries already had. This caused the count returned by the counts endpoint to not match the number of rows returned by the corresponding list query.

**cscoco.py**

On a fresh Linux install, CScout couldn't find standard headers like `stdio.h` when analyzing a project. `cscoco` only included `csmake-pre-defs.h`, which deliberately skips the compiler's real built-in macros and system include paths. It now also includes `host-defs.h` and `host-incs.h`, which contain that missing information.

## Testing

Verified against cJSON and curl on a fresh Linux install. Standard headers now resolve correctly, and query counts match their list results.